### PR TITLE
Set radii for nodes explicitly as a static radius

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,7 +45,7 @@ nimbus_fluffy_listening_port: 9009
 nimbus_fluffy_table_ip_limit: 1024
 nimbus_fluffy_bucket_ip_limit: 24
 nimbus_fluffy_bits_per_hop: 1
-nimbus_fluffy_radius: 253
+nimbus_fluffy_radius: 'static:253'
 
 # Metrics
 nimbus_fluffy_metrics_enabled: true


### PR DESCRIPTION
The radius option in Fluffy was expanded to allow for a static or
a dynamic radius. The old option where just the number was
provided was kept as working to keep backwards compatiblity. Lets
use static:253 however to be clear about current usage.