### PR TITLE
Lower fluffy nodes their radius from 253 to 252

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,7 +46,7 @@ nimbus_fluffy_listening_port: 9009
 nimbus_fluffy_table_ip_limit: 1024
 nimbus_fluffy_bucket_ip_limit: 24
 nimbus_fluffy_bits_per_hop: 1
-nimbus_fluffy_radius: 'static:253'
+nimbus_fluffy_radius: 'static:252'
 
 # Metrics
 nimbus_fluffy_metrics_enabled: true


### PR DESCRIPTION
Currently, the only  effect that this will have is store half as much **new** content and, in theory, getting half as many `FindContent` requests and `Offer`s (which should result in less database lookups) . Old content will remain on disk as is as pruning is not implemented for static radius.
However, I have a PR in the working that will soon add this functionality to fluffy, so getting this change already in so that I can then run it and lower the database size. This should have a positive effect on the currently maxed disk utilization.

A radius value of 252 should approximately half the database size. I've selected this (still quite high) amount as this value still shows decent amount of disk activity (see metrics), so that way we still have something easy to compare to as we add potential optimizations to the db.