### PR TITLE
firewall: remove the firewall creation

### DIFF
--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -1,9 +1,0 @@
----
-- name: Open Libp2p ports in iptables
-  include_role: name=infra-role-open-ports
-  vars:
-    open_ports_default_comment: '{{ nimbus_fluffy_service_name }}'
-    open_ports_default_chain: 'SERVICES'
-    open_ports_list:
-      - { port: '{{ nimbus_fluffy_listening_port }}', protocol: 'udp' }
-      - { port: '{{ nimbus_fluffy_metrics_port }}', chain: 'VPN', ipset: 'metrics.hq' }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,5 +7,4 @@
     - include_tasks: config.yml
     - include_tasks: build.yml
     - include_tasks: service.yml
-    - include_tasks: firewall.yml
     - include_tasks: consul.yml


### PR DESCRIPTION
This is now done with infra-role-open-ports from the infra-nimbus repository and playbook related to fluffy.