### PR TITLE
Remove several debug only cli options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,9 +43,6 @@ nimbus_fluffy_listening_addr: '0.0.0.0'
 nimbus_fluffy_listening_port: 9009
 
 # Limits
-nimbus_fluffy_table_ip_limit: 1024
-nimbus_fluffy_bucket_ip_limit: 24
-nimbus_fluffy_bits_per_hop: 1
 nimbus_fluffy_radius: 'dynamic'
 nimbus_fluffy_storage_capacity: 35000 # in megabytes
 

--- a/templates/fluffy.service.j2
+++ b/templates/fluffy.service.j2
@@ -29,9 +29,6 @@ ExecStart={{ nimbus_fluffy_binary_path }} \
   --rpc={{ nimbus_fluffy_rpc_enabled | to_json }} \
   --rpc-port={{ nimbus_fluffy_rpc_port }} \
   --rpc-address={{ nimbus_fluffy_rpc_address }} \
-  --table-ip-limit={{ nimbus_fluffy_table_ip_limit }} \
-  --bucket-ip-limit={{ nimbus_fluffy_bucket_ip_limit }} \
-  --bits-per-hop={{ nimbus_fluffy_bits_per_hop }} \
   --radius={{ nimbus_fluffy_radius }} \
   --storage-capacity={{ nimbus_fluffy_storage_capacity }}
 


### PR DESCRIPTION
We no longer need these variables to be set at custom values. The fleet can use the baked in defaults thanks to unique IP per node.

Furthermore, the options will be renamed with a debug prefix as this is the default way now of naming debug only (hidden) options.