### PR TITLE
rpc-api: enable options for portal,eth,discovery

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,6 +55,7 @@ nimbus_fluffy_metrics_port: 9200
 nimbus_fluffy_rpc_enabled: true
 nimbus_fluffy_rpc_address: '127.0.0.1'
 nimbus_fluffy_rpc_port: 9900
+nimbus_fluffy_rpc_api_options: 'eth,portal,discovery'
 
 # Consul service definition settings
 nimbus_fluffy_consul_service_name: 'nimbus-fluffy'

--- a/templates/fluffy.service.j2
+++ b/templates/fluffy.service.j2
@@ -29,6 +29,7 @@ ExecStart={{ nimbus_fluffy_binary_path }} \
   --rpc={{ nimbus_fluffy_rpc_enabled | to_json }} \
   --rpc-port={{ nimbus_fluffy_rpc_port }} \
   --rpc-address={{ nimbus_fluffy_rpc_address }} \
+  --rpc-api={{ nimbus_fluffy_rpc_api_options }} \
   --radius={{ nimbus_fluffy_radius }} \
   --storage-capacity={{ nimbus_fluffy_storage_capacity }}
 


### PR DESCRIPTION
This resolves our consul checks failing on fluffy nodes with:
```
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": -32601,
    "message": "'discv5_nodeInfo' is not a registered RPC method"
  }
}
```